### PR TITLE
Fix for at least 1 hour long Soundcloud tracks.

### DIFF
--- a/Extension/js/presences/Music/SoundCloud.js
+++ b/Extension/js/presences/Music/SoundCloud.js
@@ -76,6 +76,6 @@ async function updateData() {
 function getSeconds(string) {
   const a = string.split(":")
 
-  const seconds = +a[0] * 60 + +a[1]
+  const seconds = string.split(":").length - 1 > 1  ? +a[0] * 3600 + +a[1] * 60 + +a[2] : +a[0] * 60 + +a[1]
   return seconds
 }


### PR DESCRIPTION
Tracks that are at least one hour long will have two colons so this commit should check whether there are one or two colons in the timestamp, and then calculate the seconds based on that, so as to not ignore seconds when the track exceeds an hour.

This pull request should fix #140, hopefully(i haven't tested if it really works since i just edited the code on the website). O.o This is my first time trying to fix a bug/making a pull request so i hope i'm doing things right! :D