### PR TITLE
[Stable/Urgent] Fix socketio server being able to be accessed by any website

### DIFF
--- a/src/managers/socketManager.ts
+++ b/src/managers/socketManager.ts
@@ -26,6 +26,10 @@ export function init() {
 		//* If someone connects to socket socketConnection
 		server = createServer();
 		io = socketIo(server, { serveClient: false });
+		io.origins((o, c) => {
+			if (o !== '*') c('Not a chrome extension, socket denied.', false);
+			c(null, true);
+		});
 		server.listen(3020, () => {
 			//* Resolve promise
 			//* Debug info


### PR DESCRIPTION
(For the stable branch, for the PaaS branch see #500.)

**Without this patch any website can get the Discord user information if the PreMiD desktop app is running**, as it leaves the locally hosted socketio web server (port 3020) open to all origins.

This patch implements a fix which is a function that tests the origin on each socket connection, it checks if the origin is `*` as Chrome extensions appear with that origin (`*`) so it limits it to only Chrome extensions. **There are most likely better fixes which would limit it to only the PreMiD extension and not all Chrome extensions but this is the best solution for now.**

**Please merge this (or make a similar fix) quickly as this is a serious problem as it allows any website to get the Discord user information of anyone currently running PreMiD.**

It has been successfully tested on:
- Chromium-based (Brave Nightly) - Linux (Arch)
- Firefox (Nightly) - Linux (Arch)
- Chrome - Windows
- Firefox - Windows


Without fix (user info is easily got): 
![image](https://user-images.githubusercontent.com/19228318/86448565-d6410a80-bd0e-11ea-87f2-1beb9f8d299e.png)
With fix (it is blocked): ![image](https://user-images.githubusercontent.com/19228318/86448510-c0334a00-bd0e-11ea-90c3-94a85ccc11c0.png)