### PR TITLE
fix(socketManager): Fix checking Origin header

### DIFF
--- a/src/managers/socketManager.ts
+++ b/src/managers/socketManager.ts
@@ -24,7 +24,10 @@ export function init() {
 		io = new socketIo.Server(server, {
 			serveClient: false,
 			allowEIO3: true,
-			cors: { origin: "*" }
+			allowRequest: (req, callback) => {
+				const noOriginHeader = req.headers.origin === undefined;
+				callback(null, noOriginHeader);
+			}
 		});
 		server.listen(3020, () => {
 			//* Resolve promise


### PR DESCRIPTION
* Checking if Origin isn't here allows to deny requests that are coming from websites since Extension doesn't send Origin header.

Resolves #790

With patch:
![image](https://user-images.githubusercontent.com/9348108/146654793-76e50ed8-e686-4e0f-8688-b677dc186b5a.png)

Without patch:
![image](https://user-images.githubusercontent.com/9348108/146654796-d8b0679e-68f4-46a1-a061-d5e5dd7d4a68.png)
