### PR TITLE
Two things: optimized setActivity and better logging for disconnection

### DIFF
--- a/src/managers/discordManager.ts
+++ b/src/managers/discordManager.ts
@@ -35,7 +35,7 @@ class RPCClient {
 				))
 		);
 
-		this.client.login({ clientId: this.clientId }).catch(() => this.destroy());
+		this.client.login({ clientId: this.clientId }).catch(() => this.destroy("Login failed"));
 
 		info(`Create RPC client (${this.clientId})`);
 	}
@@ -50,7 +50,7 @@ class RPCClient {
 
 		this.client
 			.setActivity(presenceData.presenceData)
-			.catch(() => this.destroy());
+			.catch(() => this.destroy("setActivity failed"));
 		info("setActivity");
 	}
 
@@ -59,13 +59,13 @@ class RPCClient {
 
 		if (!this.clientReady) return;
 
-		this.client.clearActivity().catch(() => this.destroy());
+		this.client.clearActivity().catch(() => this.destroy("clearActivity failed"));
 		trayManager.tray.setTitle("");
 	}
 
-	async destroy() {
+	async destroy(reason: string) {
 		try {
-			info(`Destroy RPC client (${this.clientId})`);
+			info(`Destroy RPC client (${this.clientId}): ${reason}`);
 			if (this.clientReady) {
 				this.client.clearActivity();
 				this.client.destroy();
@@ -119,5 +119,5 @@ export async function getDiscordUser() {
 
 app.once(
 	"will-quit",
-	async () => await Promise.all(rpcClients.map(c => c.destroy()))
+	async () => await Promise.all(rpcClients.map(c => c.destroy("App quit")))
 );

--- a/src/managers/discordManager.ts
+++ b/src/managers/discordManager.ts
@@ -42,12 +42,14 @@ class RPCClient {
 	}
 
 	setActivity(presenceData?: PresenceData) {
+		presenceData = presenceData ? presenceData : this.currentPresence;
 		try {
 			deepStrictEqual(presenceData, this.currentPresence);
 			return;
-		} catch(err) {}
+		} catch(err) {
+			this.currentPresence = presenceData;
+		}
 
-		presenceData = presenceData ? presenceData : this.currentPresence;
 		if (!this.clientReady || !presenceData) return;
 
 		if (presenceData.trayTitle)

--- a/src/managers/discordManager.ts
+++ b/src/managers/discordManager.ts
@@ -1,5 +1,6 @@
 import { Client } from "discord-rpc";
 import { app } from "electron";
+import { deepStrictEqual } from "assert";
 
 import { trayManager } from "../";
 //* Import custom types
@@ -41,8 +42,12 @@ class RPCClient {
 	}
 
 	setActivity(presenceData?: PresenceData) {
-		presenceData = presenceData ? presenceData : this.currentPresence;
+		try {
+			deepStrictEqual(presenceData, this.currentPresence);
+			return;
+		} catch(err) {}
 
+		presenceData = presenceData ? presenceData : this.currentPresence;
 		if (!this.clientReady || !presenceData) return;
 
 		if (presenceData.trayTitle)

--- a/src/managers/socketManager.ts
+++ b/src/managers/socketManager.ts
@@ -67,7 +67,7 @@ function socketConnection(cSocket: socketIo.Socket) {
 		//* Show debug
 		//* Destroy all open RPC connections
 		error("Socket disconnection.");
-		rpcClients.forEach(c => c.destroy());
+		rpcClients.forEach(c => c.destroy("Socket disconnection"));
 	});
 	connected = true;
 	trayManager.update();


### PR DESCRIPTION
setActivity will now only send a request if the presence data is different from the previous request, which should decrease network load and (maybe?) reduce the chance of rate-limiting.

RPCCLient.destroy now takes a `reason` argument which will be printed along with the destroy message, useful for debugging what causes a destroy to occur.